### PR TITLE
Add 16KB page-size linker flags + bump NDK r28

### DIFF
--- a/android.sh
+++ b/android.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export ANDROID_SDK_ROOT="/Users/shabinder/Library/Android/sdk"
-export ANDROID_NDK_ROOT="/Users/shabinder/Library/Android/sdk/ndk/25.2.9519653"
+export ANDROID_NDK_ROOT="${ANDROID_NDK_ROOT:-/Users/admin/Library/Android/sdk/ndk/28.2.13676358}"
 
 if [[ -z ${ANDROID_SDK_ROOT} ]]; then
   echo -e "\n(*) ANDROID_SDK_ROOT not defined\n"

--- a/scripts/function-android.sh
+++ b/scripts/function-android.sh
@@ -91,7 +91,7 @@ APP_PLATFORM := android-${API}
 
 APP_CFLAGS := -O3 -DANDROID ${LTS_BUILD_FLAG}${BUILD_DATE} -Wall -Wno-deprecated-declarations -Wno-pointer-sign -Wno-switch -Wno-unused-result -Wno-unused-variable
 
-APP_LDFLAGS := -Wl,--hash-style=both
+APP_LDFLAGS := -Wl,--hash-style=both -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384
 EOF
 }
 
@@ -482,7 +482,7 @@ get_ldflags() {
   fi
   local COMMON_LINKED_LIBS=$(get_common_linked_libraries "$1")
 
-  echo "${ARCH_FLAGS} ${OPTIMIZATION_FLAGS} ${COMMON_LINKED_LIBS} -Wl,--hash-style=both -Wl,--exclude-libs,libgcc.a -Wl,--exclude-libs,libunwind.a"
+  echo "${ARCH_FLAGS} ${OPTIMIZATION_FLAGS} ${COMMON_LINKED_LIBS} -Wl,--hash-style=both -Wl,--exclude-libs,libgcc.a -Wl,--exclude-libs,libunwind.a -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384"
 }
 
 create_mason_cross_file() {


### PR DESCRIPTION
## Why

Google Play Console requires all native libraries shipped in APKs to be 16KB page-size aligned. The extended compliance deadline was **May 31, 2026** and is now past. The current AAR (built from this fork) ships 9 `.so` files all at `align 2**12` (4KB), so SoundBound cannot push new releases until the libraries are rebuilt with 16KB alignment.

## What

- `scripts/function-android.sh`
  - `APP_LDFLAGS` (used by `ndk-build`): append `-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384`
  - `get_ldflags()` (used by autotools/configure-based libs): append the same flags
- `android.sh`
  - `ANDROID_NDK_ROOT` default bumped to `NDK r28.2.13676358` (r28c, LTS). NDK r27+ emits 16KB-aligned `.so` by default; the explicit flags double-protect under r26 too.
  - Now `ANDROID_NDK_ROOT` is overridable via env so CI / other hosts can point at their own NDK path.

## Verification (planned)

1. `./android.sh --enable-android-zlib --enable-android-media-codec --disable-x86 --disable-x86-64`
2. `llvm-objdump -p prebuilt/bundle-android-aar/ffmpeg-kit/jni/arm64-v8a/*.so | grep 'LOAD.*align'` should show `align 2**14` (16KB) on every entry.
3. Install rebuilt AAR into SoundBound, run on Pixel_10 AVD (16KB system image) — app must boot without dynamic linker errors.

## Related

- SoundBound app PR raising the rebuilt AAR + dep upgrade in parallel.
- Custom fork patches (`Small Binary FFMpeg`, AAC support) preserved.

cc @Shabinder

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds 16KB page-size linker flags to satisfy Google Play's native library alignment requirement and bumps the default Android NDK to r28c with env-variable overridability. The linker flag changes in `scripts/function-android.sh` are correct and applied consistently to both the `ndk-build` and autotools code paths.

- `scripts/function-android.sh`: Appends `-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384` to `APP_LDFLAGS` and `get_ldflags()`, covering all build paths that produce `.so` files.
- `android.sh`: NDK default bumped to r28c (`28.2.13676358`) and made env-overridable via `${ANDROID_NDK_ROOT:-...}`. However, `ANDROID_SDK_ROOT` was not given the same treatment — it is still hardcoded to `/Users/shabinder/Library/Android/sdk` with a different username than the new NDK default (`/Users/admin/...`), meaning the SDK null-check is dead code and CI/other hosts cannot override it via environment variable.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for the linker flag changes; the SDK path hardcode will break CI or any non-Shabinder machine trying to run android.sh.

The 16KB page-size flags in `scripts/function-android.sh` are correct and self-contained. The risk lives entirely in `android.sh`: `ANDROID_SDK_ROOT` is hardcoded to a local macOS path and actively overwrites any pre-set environment value — so any CI pipeline or developer machine that exports its own `ANDROID_SDK_ROOT` will have it silently replaced, causing the build to fail when `ndk-build` tries to use `/Users/shabinder/Library/Android/sdk`. The companion null-check then can never fire to catch the problem.

android.sh — the ANDROID_SDK_ROOT export and both variable null-checks need review before this is run on any machine other than the author's local macOS setup.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| android.sh | Makes ANDROID_NDK_ROOT env-overridable and bumps NDK default to r28c, but ANDROID_SDK_ROOT remains hardcoded to a local developer path and its null-check is now permanently dead code. Default NDK path uses a different username (/Users/admin) than the SDK path (/Users/shabinder). |
| scripts/function-android.sh | Appends -Wl,-z,max-page-size=16384 and -Wl,-z,common-page-size=16384 to both APP_LDFLAGS (ndk-build path) and get_ldflags() (autotools path) — correct and consistent application of the 16KB page-size alignment flags across all build paths. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([android.sh starts]) --> B[Export ANDROID_SDK_ROOT\nhardcoded: /Users/shabinder/...]
    A --> C["Export ANDROID_NDK_ROOT\n${ANDROID_NDK_ROOT:-/Users/admin/...}"]
    C --> D{Env ANDROID_NDK_ROOT\nset?}
    D -- Yes --> E[Use env value]
    D -- No --> F[Use default r28c path]
    B --> G{ANDROID_SDK_ROOT\nempty? — DEAD CHECK}
    G -- always false --> H[Build proceeds]
    E --> H
    F --> H
    H --> I[Build libraries\nvia main-android.sh]
    I --> J[build_application_mk\nwrites Application.mk]
    J --> K["APP_LDFLAGS includes\n-Wl,-z,max-page-size=16384\n-Wl,-z,common-page-size=16384"]
    I --> L[autotools configure\ncalls get_ldflags]
    L --> M["Flags include\n-Wl,-z,max-page-size=16384\n-Wl,-z,common-page-size=16384"]
    K --> N[.so files aligned\nto 16KB pages ✓]
    M --> N
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `android.sh`, line 11-14 ([link](https://github.com/shabinder/ffmpeg-kit/blob/41307209bb500b5dc7358188cf8e106f0dc6565b/android.sh#L11-L14)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Because `ANDROID_NDK_ROOT` is now set via `${ANDROID_NDK_ROOT:-...}`, the variable can never be empty after line 4 — this guard will never trigger. While harmless today, it would mask a future regression if the default were removed.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20android.sh%0ALine%3A%2011-14%0A%0AComment%3A%0ABecause%20%60ANDROID_NDK_ROOT%60%20is%20now%20set%20via%20%60%24%7BANDROID_NDK_ROOT%3A-...%7D%60%2C%20the%20variable%20can%20never%20be%20empty%20after%20line%204%20%E2%80%94%20this%20guard%20will%20never%20trigger.%20While%20harmless%20today%2C%20it%20would%20mask%20a%20future%20regression%20if%20the%20default%20were%20removed.%0A%0A%60%60%60suggestion%0Aif%20%5B%5B%20!%20-d%20%22%24%7BANDROID_NDK_ROOT%7D%22%20%5D%5D%3B%20then%0A%20%20echo%20-e%20%22%5Cn%28*%29%20ANDROID_NDK_ROOT%20does%20not%20exist%20at%20%24%7BANDROID_NDK_ROOT%7D%5Cn%22%0A%20%20exit%201%0Afi%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=shabinder%2Fffmpeg-kit&pr=2&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shabinder%2Fffmpeg-kit%22%20on%20the%20existing%20branch%20%22chore%2F16kb-page-size%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2F16kb-page-size%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20android.sh%0ALine%3A%2011-14%0A%0AComment%3A%0ABecause%20%60ANDROID_NDK_ROOT%60%20is%20now%20set%20via%20%60%24%7BANDROID_NDK_ROOT%3A-...%7D%60%2C%20the%20variable%20can%20never%20be%20empty%20after%20line%204%20%E2%80%94%20this%20guard%20will%20never%20trigger.%20While%20harmless%20today%2C%20it%20would%20mask%20a%20future%20regression%20if%20the%20default%20were%20removed.%0A%0A%60%60%60suggestion%0Aif%20%5B%5B%20!%20-d%20%22%24%7BANDROID_NDK_ROOT%7D%22%20%5D%5D%3B%20then%0A%20%20echo%20-e%20%22%5Cn%28*%29%20ANDROID_NDK_ROOT%20does%20not%20exist%20at%20%24%7BANDROID_NDK_ROOT%7D%5Cn%22%0A%20%20exit%201%0Afi%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=shabinder%2Fffmpeg-kit&pr=2&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aandroid.sh%3A3%0A%60ANDROID_SDK_ROOT%60%20is%20still%20unconditionally%20overwritten%20with%20a%20hardcoded%20local%20path%2C%20so%20any%20value%20pre-set%20in%20the%20environment%20%28e.g.%20a%20CI%20runner%20that%20exports%20%60ANDROID_SDK_ROOT%60%29%20is%20silently%20discarded.%20The%20PR%20explicitly%20made%20%60ANDROID_NDK_ROOT%60%20env-overridable%20with%20the%20%60%24%7BVAR%3A-default%7D%60%20pattern%20but%20left%20%60ANDROID_SDK_ROOT%60%20behind%2C%20making%20the%20null-check%20on%20line%206%20permanently%20dead%20code.%0A%0A%60%60%60suggestion%0Aexport%20ANDROID_SDK_ROOT%3D%22%24%7BANDROID_SDK_ROOT%3A-%2FUsers%2Fshabinder%2FLibrary%2FAndroid%2Fsdk%7D%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aandroid.sh%3A11-14%0ABecause%20%60ANDROID_NDK_ROOT%60%20is%20now%20set%20via%20%60%24%7BANDROID_NDK_ROOT%3A-...%7D%60%2C%20the%20variable%20can%20never%20be%20empty%20after%20line%204%20%E2%80%94%20this%20guard%20will%20never%20trigger.%20While%20harmless%20today%2C%20it%20would%20mask%20a%20future%20regression%20if%20the%20default%20were%20removed.%0A%0A%60%60%60suggestion%0Aif%20%5B%5B%20!%20-d%20%22%24%7BANDROID_NDK_ROOT%7D%22%20%5D%5D%3B%20then%0A%20%20echo%20-e%20%22%5Cn%28*%29%20ANDROID_NDK_ROOT%20does%20not%20exist%20at%20%24%7BANDROID_NDK_ROOT%7D%5Cn%22%0A%20%20exit%201%0Afi%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aandroid.sh%3A4%0A**Mismatched%20username%20in%20default%20NDK%20path**%0A%0AThe%20SDK%20default%20still%20points%20to%20%60%2FUsers%2Fshabinder%2F...%60%20%28line%203%29%20while%20the%20new%20NDK%20default%20uses%20%60%2FUsers%2Fadmin%2F...%60.%20Both%20look%20like%20local%20developer%20machine%20paths%20%E2%80%94%20on%20any%20other%20host%20the%20default%20fallback%20will%20resolve%20to%20a%20non-existent%20path%20and%20the%20%60ndk-build%60%20call%20will%20fail%20at%20runtime%20rather%20than%20at%20the%20early%20validation%20check.%0A%0A&repo=shabinder%2Fffmpeg-kit&pr=2&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shabinder%2Fffmpeg-kit%22%20on%20the%20existing%20branch%20%22chore%2F16kb-page-size%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2F16kb-page-size%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aandroid.sh%3A3%0A%60ANDROID_SDK_ROOT%60%20is%20still%20unconditionally%20overwritten%20with%20a%20hardcoded%20local%20path%2C%20so%20any%20value%20pre-set%20in%20the%20environment%20%28e.g.%20a%20CI%20runner%20that%20exports%20%60ANDROID_SDK_ROOT%60%29%20is%20silently%20discarded.%20The%20PR%20explicitly%20made%20%60ANDROID_NDK_ROOT%60%20env-overridable%20with%20the%20%60%24%7BVAR%3A-default%7D%60%20pattern%20but%20left%20%60ANDROID_SDK_ROOT%60%20behind%2C%20making%20the%20null-check%20on%20line%206%20permanently%20dead%20code.%0A%0A%60%60%60suggestion%0Aexport%20ANDROID_SDK_ROOT%3D%22%24%7BANDROID_SDK_ROOT%3A-%2FUsers%2Fshabinder%2FLibrary%2FAndroid%2Fsdk%7D%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aandroid.sh%3A11-14%0ABecause%20%60ANDROID_NDK_ROOT%60%20is%20now%20set%20via%20%60%24%7BANDROID_NDK_ROOT%3A-...%7D%60%2C%20the%20variable%20can%20never%20be%20empty%20after%20line%204%20%E2%80%94%20this%20guard%20will%20never%20trigger.%20While%20harmless%20today%2C%20it%20would%20mask%20a%20future%20regression%20if%20the%20default%20were%20removed.%0A%0A%60%60%60suggestion%0Aif%20%5B%5B%20!%20-d%20%22%24%7BANDROID_NDK_ROOT%7D%22%20%5D%5D%3B%20then%0A%20%20echo%20-e%20%22%5Cn%28*%29%20ANDROID_NDK_ROOT%20does%20not%20exist%20at%20%24%7BANDROID_NDK_ROOT%7D%5Cn%22%0A%20%20exit%201%0Afi%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aandroid.sh%3A4%0A**Mismatched%20username%20in%20default%20NDK%20path**%0A%0AThe%20SDK%20default%20still%20points%20to%20%60%2FUsers%2Fshabinder%2F...%60%20%28line%203%29%20while%20the%20new%20NDK%20default%20uses%20%60%2FUsers%2Fadmin%2F...%60.%20Both%20look%20like%20local%20developer%20machine%20paths%20%E2%80%94%20on%20any%20other%20host%20the%20default%20fallback%20will%20resolve%20to%20a%20non-existent%20path%20and%20the%20%60ndk-build%60%20call%20will%20fail%20at%20runtime%20rather%20than%20at%20the%20early%20validation%20check.%0A%0A&repo=shabinder%2Fffmpeg-kit&pr=2&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add 16KB page-size linker flags for Play..."](https://github.com/shabinder/ffmpeg-kit/commit/41307209bb500b5dc7358188cf8e106f0dc6565b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35917354)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->